### PR TITLE
Add integration tests using WireMock container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
     "ruff>=0.7.0",
+    "testcontainers>=4.8.1",
+    "docker>=7.1.0",
 ]
 
 [build-system]

--- a/tests/integration/test_miro_workflow.py
+++ b/tests/integration/test_miro_workflow.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+from pydantic import SecretStr
+from testcontainers.core.container import DockerContainer  # type: ignore[import-untyped]
+
+from miro_mcp.schemas import (
+    CreateItemRequest,
+    DeleteItemRequest,
+    GetBoardItemsRequest,
+    GetItemRequest,
+    ItemPosition,
+    ListBoardsRequest,
+    ShapeItem,
+    StickyNoteItem,
+    TextItem,
+    TextItemCreate,
+    TextItemUpdate,
+    UpdateItemRequest,
+)
+from miro_mcp.service import MiroService
+from miro_mcp.settings import Settings
+
+try:  # pragma: no cover - import guard for optional dependency
+    import docker  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover - handled in fixture skip
+    docker = cast("Any", None)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+WIREMOCK_IMAGE = "wiremock/wiremock:3.9.1"
+ADMIN_RESET_PATH = "/__admin/reset"
+ADMIN_MAPPINGS_PATH = "/__admin/mappings"
+ADMIN_FIND_REQUESTS_PATH = "/__admin/requests/find"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_docker() -> None:
+    if docker is None:
+        pytest.skip("Docker SDK is required for integration tests")
+
+    client = None
+    try:
+        client = docker.from_env()
+        client.ping()
+    except docker.errors.DockerException as exc:
+        pytest.skip(f"Docker daemon is not available: {exc}")
+    finally:
+        if client is not None:
+            with contextlib.suppress(AttributeError, docker.errors.DockerException):
+                client.close()
+
+
+@pytest.fixture(scope="module")
+def wiremock_container() -> Iterator[DockerContainer]:
+    container = DockerContainer(WIREMOCK_IMAGE).with_exposed_ports(8080)
+    with container:
+        yield container
+
+
+@pytest.fixture
+async def integration_env(
+    wiremock_container: DockerContainer,
+) -> AsyncIterator[tuple[MiroService, str]]:
+    base_url = _wiremock_base_url(wiremock_container)
+    await _wait_for_wiremock(base_url)
+    await _reset_wiremock(base_url)
+    settings = Settings(
+        token=SecretStr("test-token"),
+        api_base_url=f"{base_url}/v2",
+        request_timeout_seconds=5.0,
+        user_agent="miro-mcp-integration-tests/0.1.0",
+        default_page_size=10,
+    )
+    service = MiroService.from_settings(settings)
+    try:
+        yield service, base_url
+    finally:
+        await _reset_wiremock(base_url)
+
+
+async def _reset_wiremock(base_url: str) -> None:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(f"{base_url}{ADMIN_RESET_PATH}")
+        response.raise_for_status()
+
+
+def _wiremock_base_url(container: DockerContainer) -> str:
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(8080)
+    return f"http://{host}:{port}"
+
+
+async def _wait_for_wiremock(base_url: str, *, startup_timeout: float = 30.0) -> None:
+    deadline = asyncio.get_event_loop().time() + startup_timeout
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        while True:
+            try:
+                response = await client.get(f"{base_url}{ADMIN_MAPPINGS_PATH}")
+            except httpx.HTTPError:
+                response = None
+            if response is not None and response.status_code < 500:
+                return
+            if asyncio.get_event_loop().time() >= deadline:
+                msg = "WireMock container did not become ready in time"
+                raise RuntimeError(msg)
+            await asyncio.sleep(0.5)
+
+
+async def _register_stub(
+    base_url: str,
+    *,
+    method: str,
+    url_path: str,
+    status: int,
+    body: dict[str, Any] | None = None,
+) -> None:
+    mapping: dict[str, Any] = {
+        "request": {"method": method, "urlPath": url_path},
+        "response": {"status": status},
+    }
+    if body is not None:
+        mapping["response"]["jsonBody"] = body
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(f"{base_url}{ADMIN_MAPPINGS_PATH}", json=mapping)
+        response.raise_for_status()
+
+
+async def _fetch_requests(
+    base_url: str,
+    *,
+    method: str,
+    url_path: str,
+) -> list[dict[str, Any]]:
+    criteria = {"method": method, "urlPath": url_path}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(f"{base_url}{ADMIN_FIND_REQUESTS_PATH}", json=criteria)
+        response.raise_for_status()
+    payload = response.json()
+    raw_requests = payload.get("requests", [])
+    requests: list[dict[str, Any]] = []
+    for entry in raw_requests:
+        if isinstance(entry, dict):
+            request_data = entry.get("request") if "request" in entry else entry
+            if isinstance(request_data, dict):
+                requests.append(request_data)
+    return requests
+
+
+def _extract_header(request: dict[str, Any], header_name: str) -> str | None:
+    headers = request.get("headers")
+    if not isinstance(headers, dict):
+        return None
+    target = header_name.lower()
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == target:
+            candidate = value[0] if isinstance(value, list) and value else value
+            if isinstance(candidate, str):
+                return candidate
+            return str(candidate)
+    return None
+
+
+def _request_path_and_query(request: dict[str, Any]) -> tuple[str, dict[str, list[str]]]:
+    url = request.get("url") or request.get("absoluteUrl") or ""
+    parsed = urlsplit(url)
+    return parsed.path, parse_qs(parsed.query)
+
+
+def _request_body_json(request: dict[str, Any]) -> dict[str, Any]:
+    body = request.get("bodyAsJson")
+    if isinstance(body, dict):
+        return body
+    raw_text = request.get("body")
+    if isinstance(raw_text, str) and raw_text:
+        try:
+            parsed = json.loads(raw_text)
+        except json.JSONDecodeError:  # pragma: no cover - defensive fallback
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+@pytest.mark.asyncio
+async def test_list_boards_integration(integration_env: tuple[MiroService, str]) -> None:
+    service, base_url = integration_env
+    await _register_stub(
+        base_url,
+        method="GET",
+        url_path="/v2/boards",
+        status=200,
+        body={
+            "data": [
+                {
+                    "id": "b1",
+                    "name": "Discovery Board",
+                    "description": "Team planning space",
+                    "createdAt": "2024-04-01T09:00:00Z",
+                    "modifiedAt": "2024-04-02T10:30:00Z",
+                    "owner": {"id": "u1", "name": "Pat Garcia", "type": "user"},
+                    "currentUserAccessLevel": "editor",
+                }
+            ],
+            "cursor": {"next": "next-cursor-token"},
+        },
+    )
+
+    response = await service.list_boards(ListBoardsRequest(limit=5))
+
+    assert response.next_cursor == "next-cursor-token"
+    assert len(response.boards) == 1
+    board = response.boards[0]
+    assert board.id == "b1"
+    assert board.title == "Discovery Board"
+    assert board.description == "Team planning space"
+    assert board.owner is not None
+    assert board.owner.name == "Pat Garcia"
+    assert board.access_level == "editor"
+
+    requests = await _fetch_requests(base_url, method="GET", url_path="/v2/boards")
+    assert requests, "Expected list boards request to be sent"
+    path, query = _request_path_and_query(requests[0])
+    assert path == "/v2/boards"
+    assert query.get("limit") == ["5"]
+    assert _extract_header(requests[0], "authorization") == "Bearer test-token"
+
+
+@pytest.mark.asyncio
+async def test_get_board_items_integration(integration_env: tuple[MiroService, str]) -> None:
+    service, base_url = integration_env
+    await _register_stub(
+        base_url,
+        method="GET",
+        url_path="/v2/boards/board-1/items",
+        status=200,
+        body={
+            "data": [
+                {
+                    "id": "text-1",
+                    "type": "text",
+                    "data": {"content": "Sprint goals"},
+                    "createdAt": "2024-04-03T12:00:00Z",
+                    "position": {"x": 120, "y": 80},
+                },
+                {
+                    "id": "shape-1",
+                    "type": "shape",
+                    "data": {"content": "Milestone", "shape": {"type": "rectangle"}},
+                    "modifiedAt": "2024-04-04T08:15:00Z",
+                    "geometry": {"width": 320, "height": 180},
+                },
+                {
+                    "id": "sticky-1",
+                    "type": "sticky_note",
+                    "data": {"content": "Retrospective", "shape": "square", "format": "note"},
+                    "createdAt": "2024-04-05T09:00:00Z",
+                    "position": {"x": 200, "y": 160},
+                },
+            ],
+            "cursor": {"next": "items-cursor"},
+        },
+    )
+
+    response = await service.get_board_items(GetBoardItemsRequest(board_id="board-1", limit=3))
+
+    assert response.next_cursor == "items-cursor"
+    assert len(response.items) == 3
+    assert {item.type for item in response.items} == {"text", "shape", "sticky_note"}
+    text_item = next(item for item in response.items if isinstance(item, TextItem))
+    assert text_item.content == "Sprint goals"
+    assert text_item.position is not None
+    assert text_item.position.x == 120
+    shape_item = next(item for item in response.items if isinstance(item, ShapeItem))
+    assert shape_item.shape == "rectangle"
+    sticky_item = next(item for item in response.items if isinstance(item, StickyNoteItem))
+    assert sticky_item.format == "note"
+
+    requests = await _fetch_requests(base_url, method="GET", url_path="/v2/boards/board-1/items")
+    assert requests, "Expected get_board_items request to be sent"
+    path, query = _request_path_and_query(requests[0])
+    assert path == "/v2/boards/board-1/items"
+    assert query.get("limit") == ["3"]
+    assert _extract_header(requests[0], "authorization") == "Bearer test-token"
+
+
+@pytest.mark.asyncio
+async def test_get_item_integration(integration_env: tuple[MiroService, str]) -> None:
+    service, base_url = integration_env
+    await _register_stub(
+        base_url,
+        method="GET",
+        url_path="/v2/boards/board-9/items/shape-9",
+        status=200,
+        body={
+            "id": "shape-9",
+            "type": "shape",
+            "data": {"content": "Architecture", "shape": {"type": "triangle"}},
+            "modifiedAt": "2024-04-06T07:45:00Z",
+        },
+    )
+
+    item = await service.get_item(GetItemRequest(board_id="board-9", item_id="shape-9"))
+
+    assert isinstance(item, ShapeItem)
+    assert item.id == "shape-9"
+    assert item.content == "Architecture"
+    assert item.shape == "triangle"
+
+    requests = await _fetch_requests(
+        base_url, method="GET", url_path="/v2/boards/board-9/items/shape-9"
+    )
+    assert requests, "Expected get_item request to be sent"
+    path, query = _request_path_and_query(requests[0])
+    assert path == "/v2/boards/board-9/items/shape-9"
+    assert query == {}
+    assert _extract_header(requests[0], "authorization") == "Bearer test-token"
+
+
+@pytest.mark.asyncio
+async def test_create_update_delete_item_flow(integration_env: tuple[MiroService, str]) -> None:
+    service, base_url = integration_env
+    await _register_stub(
+        base_url,
+        method="POST",
+        url_path="/v2/boards/board-2/items",
+        status=201,
+        body={
+            "id": "text-2",
+            "type": "text",
+            "data": {"content": "Integration text"},
+        },
+    )
+    await _register_stub(
+        base_url,
+        method="PATCH",
+        url_path="/v2/boards/board-2/items/text-2",
+        status=200,
+        body={
+            "id": "text-2",
+            "type": "text",
+            "data": {"content": "Updated content"},
+            "modifiedAt": "2024-04-07T12:00:00Z",
+        },
+    )
+    await _register_stub(
+        base_url,
+        method="DELETE",
+        url_path="/v2/boards/board-2/items/text-2",
+        status=204,
+        body=None,
+    )
+
+    create_response = await service.create_item(
+        CreateItemRequest(
+            board_id="board-2",
+            item=TextItemCreate(content="Integration text"),
+        )
+    )
+    assert create_response.item.id == "text-2"
+    assert create_response.item.content == "Integration text"
+
+    update_response = await service.update_item(
+        UpdateItemRequest(
+            board_id="board-2",
+            item_id="text-2",
+            item=TextItemUpdate(
+                content="Updated content",
+                position=ItemPosition(x=400.0, y=320.0),
+            ),
+        )
+    )
+    assert update_response.item.content == "Updated content"
+
+    delete_response = await service.delete_item(
+        DeleteItemRequest(board_id="board-2", item_id="text-2", hard_delete=True)
+    )
+    assert delete_response.ok is True
+
+    create_requests = await _fetch_requests(
+        base_url, method="POST", url_path="/v2/boards/board-2/items"
+    )
+    assert create_requests, "Expected create_item request"
+    create_body = _request_body_json(create_requests[0])
+    assert create_body.get("data", {}).get("content") == "Integration text"
+
+    update_requests = await _fetch_requests(
+        base_url, method="PATCH", url_path="/v2/boards/board-2/items/text-2"
+    )
+    assert update_requests, "Expected update_item request"
+    update_body = _request_body_json(update_requests[0])
+    assert update_body.get("data", {}).get("content") == "Updated content"
+    position = update_body.get("position")
+    assert position is not None
+    assert position.get("x") == 400.0
+
+    delete_requests = await _fetch_requests(
+        base_url, method="DELETE", url_path="/v2/boards/board-2/items/text-2"
+    )
+    assert delete_requests, "Expected delete_item request"
+    path, query = _request_path_and_query(delete_requests[0])
+    assert path == "/v2/boards/board-2/items/text-2"
+    assert query.get("permanent") == ["true"]
+    assert _extract_header(delete_requests[0], "authorization") == "Bearer test-token"

--- a/tests/integration/test_miro_workflow.py
+++ b/tests/integration/test_miro_workflow.py
@@ -19,6 +19,7 @@ from miro_mcp.schemas import (
     ItemPosition,
     ListBoardsRequest,
     ShapeItem,
+    ShapeItemCreate,
     StickyNoteItem,
     TextItem,
     TextItemCreate,
@@ -410,3 +411,49 @@ async def test_create_update_delete_item_flow(integration_env: tuple[MiroService
     assert path == "/v2/boards/board-2/items/text-2"
     assert query.get("permanent") == ["true"]
     assert _extract_header(delete_requests[0], "authorization") == "Bearer test-token"
+
+
+@pytest.mark.asyncio
+async def test_create_shape_item_integration(
+    integration_env: tuple[MiroService, str]
+) -> None:
+    service, base_url = integration_env
+    await _register_stub(
+        base_url,
+        method="POST",
+        url_path="/v2/boards/uXjVIA6Zsx8=/items",
+        status=201,
+        body={
+            "id": "shape-123",
+            "type": "shape",
+            "data": {"content": "Square", "shape": {"type": "rectangle"}},
+            "position": {"x": 0.0, "y": 0.0, "width": 300.0, "height": 300.0},
+        },
+    )
+
+    request = CreateItemRequest(
+        board_id="uXjVIA6Zsx8=",
+        item=ShapeItemCreate(
+            shape="rectangle",
+            content="Square",
+            position=ItemPosition(x=0.0, y=0.0, width=300.0, height=300.0),
+        ),
+    )
+
+    response = await service.create_item(request)
+
+    assert isinstance(response.item, ShapeItem)
+    assert response.item.id == "shape-123"
+    assert response.item.content == "Square"
+    assert response.item.shape == "rectangle"
+
+    requests = await _fetch_requests(
+        base_url, method="POST", url_path="/v2/boards/uXjVIA6Zsx8=/items"
+    )
+    assert requests, "Expected create_item request for shape"
+    create_body = _request_body_json(requests[0])
+    assert create_body.get("data", {}).get("content") == "Square"
+    shape_payload = create_body.get("data", {}).get("shape")
+    assert shape_payload == {"type": "rectangle"}
+    position = create_body.get("position")
+    assert position == {"x": 0.0, "y": 0.0, "width": 300.0, "height": 300.0}

--- a/uv.lock
+++ b/uv.lock
@@ -378,6 +378,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -726,11 +740,13 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "docker" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.dev-dependencies]
@@ -740,6 +756,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "docker", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "fastmcp", specifier = ">=2.12.4" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
@@ -749,6 +766,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "testcontainers", marker = "extra == 'dev'", specifier = ">=4.8.1" },
 ]
 provides-extras = ["dev"]
 
@@ -1423,6 +1441,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/ce/4fd72abe8372cc8c737c62da9dadcdfb6921b57ad8932f7a0feb605e5bf5/testcontainers-4.13.1.tar.gz", hash = "sha256:4a6c5b2faa3e8afb91dff18b389a14b485f3e430157727b58e65d30c8dcde3f3", size = 77955, upload-time = "2025-09-24T22:47:47.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/30/f0660686920e09680b8afb0d2738580223dbef087a9bd92f3f14163c2fa6/testcontainers-4.13.1-py3-none-any.whl", hash = "sha256:10e6013a215eba673a0bcc153c8809d6f1c53c245e0a236e3877807652af4952", size = 123995, upload-time = "2025-09-24T22:47:45.44Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1514,4 +1548,63 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/af/d4502dc713b4ccea7175d764718d5183caf8d0867a4f0190d5d4a45cea49/werkzeug-3.1.1.tar.gz", hash = "sha256:8cd39dfbdfc1e051965f156163e2974e52c210f130810e9ad36858f0fd3edad4", size = 806453, upload-time = "2024-11-01T16:40:45.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/ea/c67e1dee1ba208ed22c06d1d547ae5e293374bfc43e0eb0ef5e262b68561/werkzeug-3.1.1-py3-none-any.whl", hash = "sha256:a71124d1ef06008baafa3d266c02f56e1836a5984afd6dd6c9230669d60d9fb5", size = 224371, upload-time = "2024-11-01T16:40:43.994Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]


### PR DESCRIPTION
## Summary
- add a Docker-backed WireMock integration suite to exercise listing, retrieval, creation, update, and deletion flows end-to-end
- provide helpers to wait for WireMock readiness and to assert recorded requests while capturing authorization and payload details
- include testcontainers and docker as development dependencies required to run the integration tests

## Testing
- uv run ruff check --fix --no-cache
- uv run mypy --strict .
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dadadeeed8832b8da9048e0f15e8e5